### PR TITLE
Fix issues related to Deduped Bundles and Immutable Folders

### DIFF
--- a/MarrowBuildHook.cs
+++ b/MarrowBuildHook.cs
@@ -79,8 +79,8 @@ namespace MarrowBuildHook
                     try
                     {
                         ProcessGameObject(new GameObject[] { prefab }); // yayyyyy, array allocation
+                        PrefabUtility.SaveAsPrefabAsset(prefab, entry.AssetPath);
                     } catch(Exception) { }
-                    PrefabUtility.SaveAsPrefabAsset(prefab, entry.AssetPath);
                     PrefabUtility.UnloadPrefabContents(prefab);
                 }
             }

--- a/MarrowBuildHook.cs
+++ b/MarrowBuildHook.cs
@@ -75,7 +75,6 @@ namespace MarrowBuildHook
                     modifiedPrefabs.Add(entry.AssetPath, File.ReadAllText(entry.AssetPath));
 
                     var prefab = PrefabUtility.LoadPrefabContents(entry.AssetPath);
-                    if (prefab.name == "VarEnsurer") continue;
                     try
                     {
                         ProcessGameObject(new GameObject[] { prefab }); // yayyyyy, array allocation

--- a/MarrowBuildHook.cs
+++ b/MarrowBuildHook.cs
@@ -71,6 +71,7 @@ namespace MarrowBuildHook
             {
                 if (entry.MainAssetType == typeof(GameObject))
                 {
+                    if (entry.AssetPath.Contains(".obj") || entry.AssetPath.Contains(".fbx")) continue;
                     modifiedPrefabs.Add(entry.AssetPath, File.ReadAllText(entry.AssetPath));
 
                     var prefab = PrefabUtility.LoadPrefabContents(entry.AssetPath);

--- a/MarrowBuildHook.cs
+++ b/MarrowBuildHook.cs
@@ -74,6 +74,7 @@ namespace MarrowBuildHook
                     modifiedPrefabs.Add(entry.AssetPath, File.ReadAllText(entry.AssetPath));
 
                     var prefab = PrefabUtility.LoadPrefabContents(entry.AssetPath);
+                    if (prefab.name == "VarEnsurer") continue;
                     try
                     {
                         ProcessGameObject(new GameObject[] { prefab }); // yayyyyy, array allocation


### PR DESCRIPTION
Any bundles of Obj or FBX files (usually from deduping) were trying to be edited by the tool and erroring build. Skips any entries that have .obj or .fbx.

Moved the PrefabUtility.SaveAsPrefabAsset into the Try statement just in case it errors (mainly with immutable folders, like that VarEnsurer)